### PR TITLE
强制api输出header。Content-type: application/json

### DIFF
--- a/controller/api.class.php
+++ b/controller/api.class.php
@@ -2588,8 +2588,10 @@ class apiController extends appController
         $obj[ 'err_msg' ] = $msg;
         if( g('API_EMBED_MODE') == 1 )
         	return json_encode( $obj );
-        else
-        	die( json_encode( $obj ) );
+        else {
+            header('Content-type: application/json');
+            die( json_encode( $obj ) );
+        }
     }
     
     /*
@@ -2606,8 +2608,10 @@ class apiController extends appController
 
         if( g('API_EMBED_MODE') == 1 )
         	return json_encode( $obj );
-        else
-        	die( json_encode( $obj ) );
+        else {
+            header('Content-type: application/json');
+            die( json_encode( $obj ) );
+        }
     }
 }
 ?>


### PR DESCRIPTION
为了兼容一些httpclient的类库，例如：AFNetworking
