### PR TITLE
[PR] SMTP 非 25 默认端口邮件发送会失败：增加对 465 SSL 端口和 587 TLS 端口的支持

### DIFF
--- a/lib/app.function.php
+++ b/lib/app.function.php
@@ -811,6 +811,19 @@ function phpmailer_send_mail(  $to , $subject , $body , $from ,  $host , $port ,
     $mail->MsgHTML($body);
     $mail->AddAddress( $to );
 
+    switch ($port) 
+    {
+        case 465:
+            $mail->SMTPSecure = "ssl";
+            break;
+        case 587:
+            $mail->SMTPSecure = 'tls';
+            break;
+        default:
+            // Do nothing!
+            break;
+    }
+
     if(!$mail->Send())
     {
         $GLOBALS['LP_MAILER_ERROR'] = $mail->ErrorInfo;


### PR DESCRIPTION
目前通过 PHPMailer 邮件发送配置中仅使用 25 端口？

目前很多服务器提供商（比如 Gmail/Amazon SES）均默认采用 465/587 端口链接SMTP服务器，在此情况下邮件发送将失效。

此 PR 解决此问题。
